### PR TITLE
Missing .gitmodules, missing exception for .gitmodules in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ Module.symvers
 # git files that we don't want to ignore even it they are dot-files
 #
 !.gitignore
+!.gitmodules
 !.mailmap
 
 #

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "drivers/lego"]
+	path = drivers/lego
+	url = git://github.com/ev3dev/lego-linux-drivers


### PR DESCRIPTION
.gitmodules with lego-linux-drivers is missing in rpi-kernel, probably because its entry in .gitignore was also missing or maybe it's just me who's missing something...
